### PR TITLE
update repo link; bump version number

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+13
+
+* GTK3 port (Callkalpa)
+* Update repo to reflect transfer to sugarlabs (Walter)
+
 12
 
 ENHANCEMENT:
@@ -5,7 +10,8 @@ ENHANCEMENT:
 
 11
 
-???
+ENHANCEMENT:
+* add repo link to activity.info
 
 10
 

--- a/activity/activity.info
+++ b/activity/activity.info
@@ -1,10 +1,10 @@
 [Activity]
 name = Pukllanapac
-activity_version = 12
+activity_version = 13
 license = GPLv3
 bundle_id = org.sugarlabs.PukllanapacActivity
 exec = sugar-activity PukllanapacActivity.PukllanapacActivity
 icon = activity-pukllanapac
 show_launcher = yes
 category = game
-repository = https://github.com/walterbender/pukllanapac
+repository = https://github.com/sugarlabs/pukllanapac


### PR DESCRIPTION
The repository field in activity.info has been updated to reflect the transfer of the repo to the
Sugar Labs project on GitHub.

The version number has been updated to v13 for a new release that includes the GTK3 port.
